### PR TITLE
Security hardening: sanitize option keys; add Wordfence verification code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "user-admin-simplifier",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "user-admin-simplifier",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-admin-simplifier",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Lets any Administrator simplify the WordPress Admin interface, on a per-user basis, by turning specific menu/submenu sections off.",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: admin simplify menus submenus
 Requires at least: 3.0.1
 Tested up to: 6.9
-Stable tag: 3.0.0
+Stable tag: 3.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -186,6 +186,9 @@ Make css class for +/- more specific to avoid conflicts.
 2. Check the menu section to disable. Click 'Save Changes' to apply your settings. Click 'Clear User Settings' to reset the disabled menus for the selected user.
 
 == Changelog ==
+
+= 3.0.1 =
+* Security hardening: sanitize option keys when saving user settings.
 
 = 2.0.0 =
 * Major UI rewrite using React

--- a/readme.txt
+++ b/readme.txt
@@ -255,3 +255,7 @@ Bug fix.
 
 = 0.23 =
 * initial release.
+
+
+### WordFence verification code
+axjzfnshmtr7f7ggjqovzuxjzxrlpbc7

--- a/useradminsimplifier.php
+++ b/useradminsimplifier.php
@@ -68,8 +68,15 @@ License: MIT
 			wp_send_json_error( array( 'message' => esc_html__( 'No user specified', 'useradminsimplifier' ) ) );
 		}
 
+		$user_options = array();
+		if ( is_array( $options ) ) {
+			foreach ( $options as $key => $value ) {
+				$user_options[ sanitize_key( $key ) ] = intval( $value );
+			}
+		}
+
 		$uas_options = uas_get_admin_options();
-		$uas_options[ $user ] = is_array( $options ) ? array_map( 'intval', $options ) : array();
+		$uas_options[ $user ] = $user_options;
 		uas_save_admin_options( $uas_options );
 
 		wp_send_json_success( array( 'message' => esc_html__( 'Options saved successfully', 'useradminsimplifier' ) ) );

--- a/useradminsimplifier.php
+++ b/useradminsimplifier.php
@@ -71,7 +71,11 @@ License: MIT
 		$user_options = array();
 		if ( is_array( $options ) ) {
 			foreach ( $options as $key => $value ) {
-				$user_options[ sanitize_key( $key ) ] = intval( $value );
+				$clean_key = sanitize_key( $key );
+				if ( '' === $clean_key ) {
+					continue;
+				}
+				$user_options[ $clean_key ] = intval( $value );
 			}
 		}
 

--- a/useradminsimplifier.php
+++ b/useradminsimplifier.php
@@ -3,7 +3,7 @@
 Plugin Name: User Admin Simplifier
 Plugin URI: http://www.earthbound.com/plugins/user-admin-simplifier
 Description: Lets any Administrator simplify the WordPress Admin interface, on a per-user basis, by turning specific menu/submenu sections off.
-Version: 3.0.0
+Version: 3.0.1
 Author: Adam Silverstein
 Author URI: http://www.earthbound.com/plugins
 License: MIT


### PR DESCRIPTION
## Summary

Security hardening release (3.0.1) prompted by a Wordfence responsible disclosure report.

- Sanitize option array keys with `sanitize_key()` in the `uas_ajax_save_options` AJAX handler. Previously only values were sanitized (`intval`), while keys from `$_POST['options']` were stored raw in the `useradminsimplifier_options` option. Stored keys now always match the `sanitize_key()` format the read paths and React UI already use, so raw request strings can no longer be persisted.
- Add the Wordfence verification code to `readme.txt` (vendor ownership verification for the Wordfence Vulnerability Management Portal).
- Bump plugin version to 3.0.1 (plugin header, readme stable tag, changelog entry, package.json).

## Security audit notes

A full-codebase scan found no other issues: both AJAX handlers verify nonces and the `manage_options` capability, there are no direct `$wpdb` queries, all PHP output is escaped, and data passed to the React app goes through `wp_localize_script()` JSON encoding and JSX auto-escaping.

## Test plan

- [x] `php -l` passes
- [ ] Save settings for a user on the Tools > User Admin Simplifier page and confirm menus hide as before (keys sent by the UI are already `sanitize_key`-formatted, so behavior is unchanged)
- [ ] Confirm the exact reported vulnerability against the Wordfence portal report once access is verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)