### PR TITLE
Add automated WordPress.org plugin deployment for release tags

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,52 @@
+# Files and directories excluded from the WordPress.org deployment.
+# Used by 10up/action-wordpress-plugin-deploy (rsync excludes).
+
+# Version control and CI
+/.claude
+/.git
+/.github
+/.distignore
+/.gitignore
+
+# Development directories
+/node_modules
+/src
+/tests
+/test-results
+/playwright-report
+/blob-report
+/playwright
+/vendor
+/.wp-env.home
+
+# Development files
+/.eslintrc.json
+/.eslintcache
+/.nvmrc
+/.wp-env.json
+/.wp-env.override.json
+/composer.json
+/composer.lock
+/CONTRIBUTING.md
+/deploy.sh
+/E2E_TESTING_SUMMARY.md
+/index.html
+/MERGE_RESOLUTION.md
+/package.json
+/package-lock.json
+/phpstan-bootstrap.php
+/phpstan.neon
+/playwright.config.js
+/README.md
+/TEST_FIXES.md
+/test-app.html
+/webpack.config.js
+
+# IDE and OS files
+/.idea
+/.vscode
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*.log

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,73 @@
+name: Deploy to WordPress.org
+
+# Deploy when a GitHub release is published for a semantic version tag
+# (e.g. 3.0.1 or v3.0.1). Drafts and prereleases are never deployed.
+on:
+  release:
+    types: [published]
+
+# Limit permissions for security
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to WordPress.org
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Verify release tag is a semantic version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if ! echo "${TAG_VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Error: release tag '${GITHUB_REF_NAME}' is not a semantic version (expected e.g. 3.0.1 or v3.0.1)"
+            exit 1
+          fi
+
+      - name: Verify version consistency
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          README_VERSION=$(grep -m1 '^Stable tag:' readme.txt | awk '{print $3}' | tr -d '[:space:]')
+          PLUGIN_VERSION=$(grep -m1 '^Version:' useradminsimplifier.php | awk '{print $2}' | tr -d '[:space:]')
+          echo "Release tag: ${TAG_VERSION}"
+          echo "readme.txt Stable tag: ${README_VERSION}"
+          echo "Plugin header Version: ${PLUGIN_VERSION}"
+          if [ "${TAG_VERSION}" != "${README_VERSION}" ] || [ "${TAG_VERSION}" != "${PLUGIN_VERSION}" ]; then
+            echo "Error: release tag, readme.txt Stable tag, and plugin header Version must all match"
+            exit 1
+          fi
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build JavaScript
+        run: npm run build
+
+      - name: Check build artifacts
+        run: |
+          if [ ! -f build/admin.js ]; then
+            echo "Error: build/admin.js was not created"
+            exit 1
+          fi
+          if [ ! -f build/admin.css ]; then
+            echo "Error: build/admin.css was not created"
+            exit 1
+          fi
+          echo "Build artifacts created successfully"
+
+      - name: Deploy to WordPress.org
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SLUG: user-admin-simplifier

--- a/README.md
+++ b/README.md
@@ -166,6 +166,41 @@ See `.github/workflows/visual-regression.yml` for the full configuration.
 - Check the Playwright HTML report in CI artifacts
 - Run `npm run test:visual:ui` locally for interactive debugging
 
+## Deployment
+
+Releases are deployed to the [WordPress.org plugin directory](https://wordpress.org/plugins/user-admin-simplifier/) automatically via the [10up/action-wordpress-plugin-deploy](https://github.com/10up/action-wordpress-plugin-deploy) GitHub Action. See `.github/workflows/deploy.yml`.
+
+### How it works
+
+Publishing a GitHub release for a semantic version tag (e.g. `3.0.1` or `v3.0.1`) triggers the deployment workflow, which:
+
+1. Verifies the release is not a draft or prerelease
+2. Verifies the release tag, the `Stable tag` in `readme.txt`, and the `Version` in the plugin header all match
+3. Builds the JavaScript assets with `npm run build`
+4. Commits the plugin to the WordPress.org SVN repository (trunk and a version tag), excluding development files listed in `.distignore`
+
+### Releasing a new version
+
+1. Update the version number in `useradminsimplifier.php` (`Version` header), `readme.txt` (`Stable tag`), and `package.json`
+2. Update the changelog in `readme.txt`
+3. Merge the changes to `main`
+4. Create and publish a GitHub release with a tag matching the new version (e.g. `3.0.1`)
+
+The workflow then deploys to WordPress.org. If any version check fails, the workflow exits without deploying.
+
+### Required repository secrets
+
+The workflow needs two [GitHub Actions secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions) configured under **Settings → Secrets and variables → Actions**:
+
+| Secret | Description |
+|--------|-------------|
+| `SVN_USERNAME` | WordPress.org username with commit access to the plugin SVN repository |
+| `SVN_PASSWORD` | The corresponding WordPress.org password |
+
+### Excluded files
+
+Development files (source, tests, build tooling, CI configuration) are excluded from the deployed package via `.distignore`. The deployed package contains only the runtime files: the main plugin file, `uninstall.php`, `readme.txt`, and the `build/`, `includes/`, and `images/` directories.
+
 ## License
 
 MIT License - see LICENSE file for details.


### PR DESCRIPTION
Fixes #27

Adds automated deployment to the WordPress.org plugin directory using [10up/action-wordpress-plugin-deploy](https://github.com/10up/action-wordpress-plugin-deploy), as proposed in #27.

## Changes

- **`.github/workflows/deploy.yml`** - New workflow that deploys to WordPress.org when a GitHub release is published. Production-ready guards:
  - Drafts and prereleases are never deployed
  - The release tag must be a semantic version (`3.0.1` or `v3.0.1`)
  - The release tag, `readme.txt` `Stable tag`, and plugin header `Version` must all match, or the workflow fails before deploying
  - JavaScript assets are built fresh in CI (`npm ci && npm run build`) and verified before deployment
  - The 10up action is pinned to a full commit SHA (`54bd289`, release 2.3.0) and workflow permissions are limited to `contents: read`
- **`.distignore`** - Excludes development files (source, tests, build tooling, CI config) from the deployed package. The shipped package contains only the main plugin file, `uninstall.php`, `readme.txt`, `build/`, `includes/`, and `images/`
- **`README.md`** - New Deployment section documenting the workflow, the release process, and the required secrets

## Required setup before first use

Two repository secrets must be added under **Settings → Secrets and variables → Actions**:

| Secret | Value |
|--------|-------|
| `SVN_USERNAME` | WordPress.org username with commit access to the plugin SVN repo |
| `SVN_PASSWORD` | The corresponding WordPress.org password |

## Notes

- The trigger is `release: published` rather than raw tag pushes - this is the 10up-recommended pattern and adds a deliberate publish step as the production gate, while still matching the tag-driven flow described in the issue
- Existing tags in this repo use plain semver (`3.0.0`); the workflow accepts both `3.0.0` and `v3.0.0` forms
- The legacy manual `deploy.sh` script is left in place untouched; it can be removed in a follow-up once the automated flow has shipped a release

## Verification

- Workflow YAML parses cleanly (js-yaml)
- The version-check shell logic was run locally against the real `readme.txt` and `useradminsimplifier.php` (match detected for `3.0.0`, mismatches and non-semver tags rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)