### PR TITLE
Fix e2e test failures on modern WordPress

### DIFF
--- a/tests/e2e/admin-bar.spec.js
+++ b/tests/e2e/admin-bar.spec.js
@@ -64,8 +64,8 @@ test.describe('Admin Bar Customization', () => {
     // Wait for content to load by checking for any checkbox or input
     await expect(page.locator('input[type="checkbox"]').first()).toBeVisible({ timeout: 5000 });
     
-    // Look for admin bar disable checkbox or option
-    const adminBarOption = page.locator('text=/disable.*admin bar/i, input[id*="admin-bar"], input[name*="admin-bar"]').first();
+    // Look for the admin bar disable checkbox
+    const adminBarOption = page.getByRole('checkbox', { name: /disable the admin bar/i });
     await expect(adminBarOption).toBeVisible();
   });
 

--- a/tests/e2e/plugin-ui.spec.js
+++ b/tests/e2e/plugin-ui.spec.js
@@ -16,7 +16,7 @@ test.describe('Plugin UI', () => {
     await expect(page.locator('#uas-react-root')).toBeVisible();
     
     // Check that main title is present
-    await expect(page.locator('h1')).toContainText('User Admin Simplifier');
+    await expect(page.getByRole('heading', { name: 'User Admin Simplifier' })).toBeVisible();
   });
 
   test('should display user selector', async ({ page }) => {

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -49,7 +49,7 @@ test.describe('Smoke Tests', () => {
     await expect(page.locator('#uas-react-root')).toBeVisible({ timeout: 10000 });
     
     // Check for plugin title
-    await expect(page.locator('h1')).toContainText('User Admin Simplifier');
+    await expect(page.getByRole('heading', { name: 'User Admin Simplifier' })).toBeVisible();
   });
 
   test('React app renders without errors', async ({ page }) => {

--- a/tests/e2e/utils/wordpress.js
+++ b/tests/e2e/utils/wordpress.js
@@ -81,8 +81,18 @@ export async function createTestUser(page, userData = {}) {
   await page.fill('#first_name', user.firstName);
   await page.fill('#last_name', user.lastName);
   await page.fill('#pass1', user.password);
-  await page.fill('#pass2', user.password);
-  
+
+  // The confirm field (#pass2) is hidden when JavaScript is enabled, and a
+  // weak-password confirmation checkbox may appear - handle both.
+  const pass2 = page.locator('#pass2');
+  if (await pass2.isVisible()) {
+    await pass2.fill(user.password);
+  }
+  const weakConfirm = page.locator('.pw-weak input.pw-checkbox');
+  if (await weakConfirm.isVisible()) {
+    await weakConfirm.check();
+  }
+
   // Select role
   await page.selectOption('#role', user.role);
   


### PR DESCRIPTION
## Summary

The e2e suite has failed on every run since it landed (including on main). Two distinct pre-existing bugs in the tests themselves:

- **Hidden password confirm field**: `createTestUser` filled `#pass2` on `user-new.php`, but WordPress hides the confirm-password field when JavaScript is enabled - the element exists but is never visible, so `page.fill` timed out and every spec that creates a test user (`admin-bar`, `menu-management`, `menu-visibility`) failed in `beforeAll`. Now it only fills `#pass2` when visible and confirms the weak-password checkbox if WordPress shows one.
- **Wrong heading level asserted**: `smoke.spec.js` and `plugin-ui.spec.js` asserted an `h1` containing "User Admin Simplifier", but the React app renders its title as an `h2`, so the assertion always timed out with "element(s) not found". Replaced with a role-based heading locator that is robust to heading level. (Switching the app to an `h1` would match WordPress admin a11y guidance, but that would invalidate the committed linux visual-regression baselines, so it's left as a follow-up.)

This unblocks PR #26 and the open Dependabot PRs, which all fail this same check.

## Test plan

- [x] Failure analysis from CI run logs (run 27233372055): all failures trace to these two causes
- [ ] e2e-tests (18.x) check green on this PR (Docker unavailable locally; CI is the verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)