### PR TITLE
Fix race conditions in flaky e2e save/reset tests

### DIFF
--- a/tests/e2e/menu-management.spec.js
+++ b/tests/e2e/menu-management.spec.js
@@ -95,14 +95,16 @@ test.describe('Menu Management', () => {
       await targetCheckbox.click();
     }
     
-    // Save settings
+    // Save settings and wait for the AJAX request to complete - relying on
+    // networkidle races against the reload aborting the in-flight save.
     const saveButton = page.locator('button:has-text("Save")');
     await expect(saveButton).toBeVisible();
-    await saveButton.click();
-    
-    // Wait for page to update (check for success or wait for network idle)
-    await page.waitForLoadState('networkidle');
-    
+    const [saveResponse] = await Promise.all([
+      page.waitForResponse((resp) => resp.url().includes('admin-ajax.php')),
+      saveButton.click(),
+    ]);
+    expect(saveResponse.ok()).toBeTruthy();
+
     // Reload the page
     await page.reload();
     await expect(userSelector).toBeVisible();
@@ -155,20 +157,25 @@ test.describe('Menu Management', () => {
     await checkboxes.nth(0).click();
     await checkboxes.nth(1).click();
     
-    // Save settings
+    // Save settings and wait for the AJAX request to complete - relying on
+    // networkidle races against the reload aborting the in-flight request.
     const saveButton = page.locator('button:has-text("Save")');
     await expect(saveButton).toBeVisible();
-    await saveButton.click();
-    await page.waitForLoadState('networkidle');
-    
-    // Click reset button
+    const [saveResponse] = await Promise.all([
+      page.waitForResponse((resp) => resp.url().includes('admin-ajax.php')),
+      saveButton.click(),
+    ]);
+    expect(saveResponse.ok()).toBeTruthy();
+
+    // Reset and wait for its AJAX request to complete as well
     const resetButton = page.locator('button:has-text("Reset")');
     await expect(resetButton).toBeVisible();
-    await resetButton.click();
-    
-    // Wait for reset to complete
-    await page.waitForLoadState('networkidle');
-    
+    const [resetResponse] = await Promise.all([
+      page.waitForResponse((resp) => resp.url().includes('admin-ajax.php')),
+      resetButton.click(),
+    ]);
+    expect(resetResponse.ok()).toBeTruthy();
+
     // Reload page
     await page.reload();
     await expect(userSelector).toBeVisible();

--- a/tests/e2e/utils/wordpress.js
+++ b/tests/e2e/utils/wordpress.js
@@ -135,7 +135,14 @@ export async function deleteTestUser(page, username) {
     // Click delete link
     const deleteLink = userRow.first().locator('a:has-text("Delete")');
     await deleteLink.click();
-    
+
+    // If the user has content, WordPress disables the confirm button until
+    // a content-disposition option is chosen - pick "Delete all content".
+    const deleteContentOption = page.locator('#delete_option0');
+    if (await deleteContentOption.isVisible().catch(() => false)) {
+      await deleteContentOption.check();
+    }
+
     // Confirm deletion
     await page.click('#submit');
     


### PR DESCRIPTION
## Summary

The `should persist menu settings after save` and `should reset user settings when reset button is clicked` tests have failed intermittently across unrelated PRs (#20, #29, #35 - the reset test failed all 3 attempts on each). Root cause: the tests click Save/Reset and then `waitForLoadState('networkidle')`, which resolves immediately when the page is already idle, so the following `page.reload()` aborts the in-flight `admin-ajax.php` request and the write is lost.

- Wait for the actual `admin-ajax.php` response (and assert it's OK) after clicking Save/Reset, before reloading.
- In `deleteTestUser`, select the "Delete all content" option when WordPress asks - the Confirm Deletion button is disabled until a choice is made, which made `afterAll` cleanup time out for test users who created content.

## Test plan

- [ ] e2e-tests (18.x) green on this PR (the affected tests run in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of menu management tests through enhanced synchronization with server responses.
  * Enhanced test utilities to better handle WordPress user deletion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->