### PR TITLE
Mark compatible with WordPress 7.1

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-  "core": "WordPress/WordPress#6.4",
+  "core": null,
   "phpVersion": "8.0",
   "plugins": [
     "."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "user-admin-simplifier",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "user-admin-simplifier",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-admin-simplifier",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Lets any Administrator simplify the WordPress Admin interface, on a per-user basis, by turning specific menu/submenu sections off.",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: adamsilverstein
 Donate link:
 Tags: admin simplify menus submenus
 Requires at least: 3.0.1
-Tested up to: 6.9
-Stable tag: 3.1.0
+Tested up to: 7.1
+Stable tag: 3.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -196,6 +196,9 @@ Make css class for +/- more specific to avoid conflicts.
 2. Check the menu section to disable. Click 'Save Changes' to apply your settings. Click 'Clear User Settings' to reset the disabled menus for the selected user.
 
 == Changelog ==
+
+= 3.1.1 =
+* Confirm compatibility with WordPress 7.1.
 
 = 3.1.0 =
 * Add role-based menu control: hide menus and submenus by user role, with optional per-user overrides.

--- a/useradminsimplifier.php
+++ b/useradminsimplifier.php
@@ -3,7 +3,7 @@
 Plugin Name: User Admin Simplifier
 Plugin URI: http://www.earthbound.com/plugins/user-admin-simplifier
 Description: Lets any Administrator simplify the WordPress Admin interface, on a per-user basis, by turning specific menu/submenu sections off.
-Version: 3.1.0
+Version: 3.1.1
 Author: Adam Silverstein
 Author URI: http://www.earthbound.com/plugins
 License: MIT


### PR DESCRIPTION
_Claude did the digging here, findings below:_

Bumps `Tested up to` to 7.1 ahead of tomorrow's release, and cuts 3.1.1 so the change actually reaches the plugin directory. The deploy workflow only fires on a published release, so a readme edit on its own would leave the directory still advertising 6.9.

Also unpins `.wp-env.json` from `WordPress/WordPress#6.4` so the dev and CI environment tracks the current release instead of a version from 2023.

### Testing

Verified against WordPress 7.1-RC3 in wp-env on PHP 8.3, with `WP_DEBUG` on and this plugin the only one active:

- Dashboard, the Tools &rarr; User Admin Simplifier screen, and the front end all load clean: no PHP notices in `debug.log`, no JavaScript console or page errors.
- `npm run test:php` &mdash; 13 passed, 0 failed.
- `vendor/bin/phpstan analyse` &mdash; no errors.

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.
